### PR TITLE
Export poll::PollData from the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod hello;
 pub mod host;
 pub mod login;
 pub mod logout;
+pub mod poll;
 pub mod request;
 pub mod response;
 pub mod xml;
@@ -61,9 +62,6 @@ pub mod extensions {
         pub const XMLNS: &str = "urn:ietf:params:xml:ns:rgp-1.0";
     }
 }
-
-mod poll;
-pub use poll::{Ack, Poll, PollData};
 
 pub use client::EppClient;
 pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub mod extensions {
 }
 
 mod poll;
-pub use poll::{Ack, Poll};
+pub use poll::{Ack, Poll, PollData};
 
 pub use client::EppClient;
 pub use error::Error;


### PR DESCRIPTION
Missed this in #7, so now the PollData type cannot be named.