### PR TITLE
Secdns ergonomic

### DIFF
--- a/src/extensions/secdns.rs
+++ b/src/extensions/secdns.rs
@@ -119,11 +119,11 @@ pub struct DsDataType<'a> {
 }
 
 impl<'a> DsDataType<'a> {
-    pub fn new<D: Into<Cow<'a, str>>>(
+    pub fn new(
         key_tag: u16,
         algorithm: Algorithm,
         digest_type: DigestAlgorithm,
-        digest: D,
+        digest: impl Into<Cow<'a, str>>,
         key_data: Option<KeyDataType<'a>>,
     ) -> Self {
         Self {

--- a/src/extensions/secdns.rs
+++ b/src/extensions/secdns.rs
@@ -119,11 +119,11 @@ pub struct DsDataType<'a> {
 }
 
 impl<'a> DsDataType<'a> {
-    pub fn new(
+    pub fn new<D: Into<Cow<'a, str>>>(
         key_tag: u16,
         algorithm: Algorithm,
         digest_type: DigestAlgorithm,
-        digest: &'a str,
+        digest: D,
         key_data: Option<KeyDataType<'a>>,
     ) -> Self {
         Self {

--- a/src/extensions/secdns.rs
+++ b/src/extensions/secdns.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use std::time::Duration;
 
+use crate::common::NoExtension;
 use crate::request::{Extension, Transaction};
 
 pub const XMLNS: &str = "urn:ietf:params:xml:ns:secDNS-1.1";
@@ -13,7 +14,7 @@ pub const XMLNS: &str = "urn:ietf:params:xml:ns:secDNS-1.1";
 impl<'a> Transaction<CreateData<'a>> for crate::domain::create::DomainCreate<'a> {}
 
 impl<'a> Extension for CreateData<'a> {
-    type Response = ();
+    type Response = NoExtension;
 }
 
 #[derive(Debug, ToXml)]


### PR DESCRIPTION
* Change the `Extension::Response` type to `NoExtension`,
* make `DsDataType::new()` accepts `Into<Cow<'_, str>>` so that we can pass either a `&str` or a `String`.